### PR TITLE
Trading Wallet getAssetBalanceAsync refactor

### DIFF
--- a/examples/lib/tradingWallet/balances/getTokenBalance.js
+++ b/examples/lib/tradingWallet/balances/getTokenBalance.js
@@ -1,0 +1,12 @@
+(async () => {
+  const { TradingWalletServiceBuilder } = require('@eidoo/hybrid-exchange-sdk').factories
+
+  const tradingWalletService = TradingWalletServiceBuilder.build()
+
+  const personalWalletAddress = '0xcf4b07a79b5d29988f488f30c4a676ecaad35c02'
+  const tradingWalletAddress = '0x9c6d1840381cc570235a4ed867bf8465e32ce753'
+  const tokenAddress = '0x9727e2fb13f7f42d5a6f1a4a9877d4a7e0404d6a'
+  const assetBalance = await tradingWalletService
+    .getAssetBalanceAsync(personalWalletAddress, tokenAddress, tradingWalletAddress)
+  console.log(assetBalance)
+})()

--- a/src/services/TradingWalletService.js
+++ b/src/services/TradingWalletService.js
@@ -176,21 +176,23 @@ class TradingWalletService extends BaseTransactionService {
     this.checkEtherumAddress(personalWalletAddress)
     this.checkEtherumAddress(tokenAddress)
 
-    let currentTradingWalletAddress = tradingWalletAddress
-    if (!currentTradingWalletAddress) {
-      currentTradingWalletAddress = await this.getTradingWalletAddressAsync(personalWalletAddress)
-      if (!currentTradingWalletAddress) {
-        this.log.error(
-          { fn: 'getAssetBalanceAsync' },
-          `tradingWallet not found for EOA:${personalWalletAddress}`,
-        )
-        throw new TradingWalletNotFoundError(`No trading wallet address for: ${personalWalletAddress}`)
-      }
+    let retrievedTradingWalletAddress = tradingWalletAddress
+
+    if (!tradingWalletAddress) {
+      retrievedTradingWalletAddress = await this.getTradingWalletAddressAsync(personalWalletAddress)
+    }
+
+    if (retrievedTradingWalletAddress === null) {
+      this.log.error(
+        { fn: 'getAssetBalanceAsync' },
+        `tradingWallet not found for EOA:${personalWalletAddress}`,
+      )
+      throw new TradingWalletNotFoundError(`No trading wallet address for: ${personalWalletAddress}`)
     }
 
     const transactionObjectDraft = this.transactionBuilder.buildAssetBalanceTransactionDraft(
       personalWalletAddress,
-      currentTradingWalletAddress,
+      retrievedTradingWalletAddress,
       tokenAddress,
     )
 

--- a/src/services/TradingWalletService.js
+++ b/src/services/TradingWalletService.js
@@ -167,26 +167,30 @@ class TradingWalletService extends BaseTransactionService {
    * The `tokenBalances_` method of trading wallet smart contract should be called to
    * retrieve the amount of the owned asset.
    *
-   * @param {String} personalWalletAddress The personal wallet address, owner of the  (EOA).
+   * @param {String} personalWalletAddress The personal wallet address (EOA).
    * @param {String} tokenAddress          The address of the owned asset.
+   * @param {String} tradingWalletAddress  The trading wallet address address.
    * @throws {InvalidEthereumAddress}      If personalWalletAddress or the tokenAddress is not a valid ethereum address.
    */
-  async getAssetBalanceAsync(personalWalletAddress, tokenAddress) {
+  async getAssetBalanceAsync(personalWalletAddress, tokenAddress, tradingWalletAddress = null) {
     this.checkEtherumAddress(personalWalletAddress)
     this.checkEtherumAddress(tokenAddress)
 
-    const tradingWalletAddress = await this.getTradingWalletAddressAsync(personalWalletAddress)
-    if (!tradingWalletAddress) {
-      this.log.error(
-        { fn: 'getAssetBalanceAsync' },
-        `tradingWallet not found for EOA:${personalWalletAddress}`,
-      )
-      throw new TradingWalletNotFoundError(`No trading wallet address for: ${personalWalletAddress}`)
+    let currentTradingWalletAddress = tradingWalletAddress
+    if (!currentTradingWalletAddress) {
+      currentTradingWalletAddress = await this.getTradingWalletAddressAsync(personalWalletAddress)
+      if (!currentTradingWalletAddress) {
+        this.log.error(
+          { fn: 'getAssetBalanceAsync' },
+          `tradingWallet not found for EOA:${personalWalletAddress}`,
+        )
+        throw new TradingWalletNotFoundError(`No trading wallet address for: ${personalWalletAddress}`)
+      }
     }
 
     const transactionObjectDraft = this.transactionBuilder.buildAssetBalanceTransactionDraft(
       personalWalletAddress,
-      tradingWalletAddress,
+      currentTradingWalletAddress,
       tokenAddress,
     )
 

--- a/tests/unit/services/TradingWalletService.test.js
+++ b/tests/unit/services/TradingWalletService.test.js
@@ -186,7 +186,7 @@ describe('getAssetBalanceAsync', () => {
     expect(tradingWalletService.getAssetBalanceAsync(personalWalletAddress, tokenAddress))
       .rejects.toBeInstanceOf(TradingWalletNotFoundError)
   })
-  test('calls correctly ethapi transactionCallAsync correctly', async() => {
+  test('calls correctly ethapi transactionCallAsync correctly without specifying a trading wallet address', async() => {
     const expectedAssetBalance = web3.toBigNumber(web3.toWei(5)).toString(10)
 
     sandbox.stub(tradingWalletService, 'getTradingWalletAddressAsync').returns(tradingWalletOfThePersonalWallet)
@@ -195,6 +195,18 @@ describe('getAssetBalanceAsync', () => {
     const tradingWalletAssetBalanceResult = await tradingWalletService.getAssetBalanceAsync(
       personalWalletAddress,
       tokenAddress,
+    )
+
+    expect(tradingWalletAssetBalanceResult).toEqual(expectedAssetBalance)
+  })
+  test('calls correctly ethapi transactionCallAsync correctly specifying a trading wallet address', async() => {
+    const expectedAssetBalance = web3.toBigNumber(web3.toWei(5)).toString(10)
+    sandbox.stub(ethApiLib, 'transactionCallAsync').returns(expectedAssetBalance)
+
+    const tradingWalletAssetBalanceResult = await tradingWalletService.getAssetBalanceAsync(
+      personalWalletAddress,
+      tokenAddress,
+      tradingWalletOfThePersonalWallet,
     )
 
     expect(tradingWalletAssetBalanceResult).toEqual(expectedAssetBalance)


### PR DESCRIPTION
### 📝 Issue

Resolves #21 

### 📖 Notes

Refactor of trading wallet service getAssetBalanceAsync:
- if trading wallet not specified retrieve it
- if specified use the specified